### PR TITLE
Add fetch for closed thread info retrieval

### DIFF
--- a/cogs/dispander.py
+++ b/cogs/dispander.py
@@ -79,6 +79,8 @@ class ExpandDiscordMessageUrl(commands.Cog):
     @staticmethod
     async def fetch_message_from_id(guild, channel_id, message_id):
         channel = guild.get_channel_or_thread(channel_id)
+        if channel is None:
+            channel = await guild.fetch_channel(channel_id)
         try:
             message = await channel.fetch_message(message_id)
             return message


### PR DESCRIPTION
To ensure the bot can retrieve information from closed threads, the code now includes a conditional check where if the channel object is None, it attempts to fetch the channel using the guild.fetch_channel method with the given channel_id.

https://github.com/being24/Satsuki/assets/57354947/a4d5e89d-e39f-47d7-ac15-baaaf12e53a5

